### PR TITLE
update selenium-webdriver / rubyzip vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (2.0.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -222,9 +222,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (3.142.4)
+    selenium-webdriver (3.142.5)
       childprocess (>= 0.5, < 3.0)
-      rubyzip (~> 1.2, >= 1.2.2)
+      rubyzip (>= 1.2.2)
     simple_form (5.0.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)


### PR DESCRIPTION
* update selenium-webdriver
  * fix CVE-2019-16892 `rubyzip`
  * https://nvd.nist.gov/vuln/detail/CVE-2019-16892
* run `bundle update selenium-webdriver`